### PR TITLE
Add limit of before php 5.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.3.3,<5.6",
         "symfony/polyfill-util": "~1.0"
     },
     "autoload": {


### PR DESCRIPTION
Add limit of before php 5.6 - so that the package does not install where not required.